### PR TITLE
Fix function names and line numbers in messages.

### DIFF
--- a/b-log.sh
+++ b/b-log.sh
@@ -256,10 +256,10 @@ function B_LOG_convert_template() {
                 log_layout_part="${B_LOG_LOG_LEVEL_NAME}"
                 ;;
             3) # function name
-                log_layout_part="${FUNCNAME[2]}"
+                log_layout_part="${FUNCNAME[3]}"
                 ;;
             4) # line number
-                log_layout_part="${BASH_LINENO[1]}"
+                log_layout_part="${BASH_LINENO[2]}"
                 ;;
             5) # message
                 log_layout_part="${B_LOG_LOG_MESSAGE}"


### PR DESCRIPTION
#1 broke the display of function names and line numbers in messages by nesting them one layer deeper in the FUNCNAME and BASH_LINENO arrays because the log commands were changed from aliases to functions.

Output before fix:
```
$ ./examples/01_basic_example.sh 
[2017-08-24 17:42:29.826][FATAL ][FATAL:387] fatal level
[2017-08-24 17:42:29.829][ERROR ][ERROR:390] error level
[2017-08-24 17:42:29.831][WARN  ][WARN:393] warning level
[2017-08-24 17:42:29.834][NOTICE][NOTICE:396] notice level
[2017-08-24 17:42:29.838][INFO  ][INFO:399] info level
[2017-08-24 17:42:29.841][DEBUG ][DEBUG:402] debug level
[2017-08-24 17:42:29.845][TRACE ][TRACE:405] trace level
```

Output after fix:
```
$ ./examples/01_basic_example.sh 
[2017-08-24 17:52:47.401][FATAL ][main:5  ] fatal level
[2017-08-24 17:52:47.403][ERROR ][main:6  ] error level
[2017-08-24 17:52:47.405][WARN  ][main:7  ] warning level
[2017-08-24 17:52:47.406][NOTICE][main:8  ] notice level
[2017-08-24 17:52:47.409][INFO  ][main:9  ] info level
[2017-08-24 17:52:47.411][DEBUG ][main:10 ] debug level
[2017-08-24 17:52:47.414][TRACE ][main:11 ] trace level
```