### PR TITLE
Fix problem with time format on Alpine Linux

### DIFF
--- a/b-log.sh
+++ b/b-log.sh
@@ -77,7 +77,7 @@ B_LOG_LOG_VIA_FILE_PREFIX=false # add prefix to log file
 B_LOG_LOG_VIA_FILE_SUFFIX=false # add suffix to log file
 B_LOG_LOG_VIA_SYSLOG=""         # syslog flags so that "syslog 'flags' message"
 B_LOG_TS=""                     # timestamp variable
-B_LOG_TS_FORMAT="%Y-%m-%d %H:%M:%S.%N" # timestamp format
+B_LOG_TS_FORMAT="%Y-%m-%d$(echo -e "\uA0")%H:%M:%S.%N" # timestamp format
 B_LOG_LOG_LEVEL_NAME=""         # the name of the log level
 B_LOG_LOG_MESSAGE=""            # the log message
 


### PR DESCRIPTION
When I use b-log.sh in Docker image based on Alpine I find out that normal space is treated as field separator and each part of date was put in separate 23 characters long field. $(echo -e "\uA0") generate non breaking space which prevents this behavior.